### PR TITLE
Challenge additions

### DIFF
--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -59,9 +59,15 @@ submit_button.addEventListener("click", () => {
             }
          })
       } else {
-         // Display error message
          let addr_results_div = document.getElementById("address-results");
          addr_results_div.style.display = 'block';
+
+         // Remove old elements if exist
+         while (addr_results_div.firstChild) {
+            addr_results_div.removeChild(addr_results_div.firstChild);
+         }
+
+         // Display error message
          let h3 = document.createElement("h3");
          let h3_text = document.createTextNode("Invalid address. Please try again with a valid address.");
          h3.appendChild(h3_text);

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -21,17 +21,29 @@ submit_button.addEventListener("click", () => {
       if (response['status'] == 200) {
          response.json()
          .then(data => {
+            console.log(data);
             let addr_results_div = document.getElementById("address-results");
             
             // Show hidden html element
             addr_results_div.style.display = 'block';
 
-            // Append elements to html
             let addr_type_strong = document.getElementById("parse-type");
+            var comp_table_body = addr_results_div.children[2].children[1]
+
+            // Remove old text
+            if (addr_type_strong.textContent != "") { 
+               addr_type_strong.textContent = "";
+            }
+
+            // Remove old elements if exist
+            while (comp_table_body.firstChild) {
+               comp_table_body.removeChild(comp_table_body.firstChild);
+            }
+
+            // Append new elements to html
             let addr_type_text = document.createTextNode(data["address_type"]);
             addr_type_strong.appendChild(addr_type_text);
 
-            var comp_table_body = addr_results_div.children[2].children[1]
             for (const [key, value] of Object.entries(data["address_components"])) {
                let tr = document.createElement("tr");
                let th1 = document.createElement("th");

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -46,14 +46,14 @@ submit_button.addEventListener("click", () => {
 
             for (const [key, value] of Object.entries(data["address_components"])) {
                let tr = document.createElement("tr");
-               let th1 = document.createElement("th");
-               let th2 = document.createElement("th");
+               let td1 = document.createElement("td");
+               let td2 = document.createElement("td");
                let addr_comp_type = document.createTextNode(key);
                let addr_comp_text = document.createTextNode(value);
-               th1.appendChild(addr_comp_type);
-               th2.appendChild(addr_comp_text);
-               tr.appendChild(th1);
-               tr.appendChild(th2);
+               td1.appendChild(addr_comp_type);
+               td2.appendChild(addr_comp_text);
+               tr.appendChild(td1);
+               tr.appendChild(td2);
 
                comp_table_body.appendChild(tr);
             }

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,23 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+
+// add on click
+console.log("adding on click method")
+let submit_button = document.getElementById("submit");
+submit_button.addEventListener("click", parse_address());
+
+function parse_address() {
+   console.log("Parsing address");
+   // grab input data
+   let input_address = document.getElementById("address").value;
+
+   // call api
+   let request = fetch("",
+                       {method: 'POST',
+                        body: JSON.stringify({"address": input_address})});
+   
+   request.then((response) => response.json())
+          .then(data => {
+            // display data in html
+          })
+}

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,55 +1,60 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
 
-// add on click
-console.log("adding on click method")
 let submit_button = document.getElementById("submit");
-submit_button.addEventListener("click", parse_address => {
+
+// add on click
+console.log("adding on click method");
+submit_button.addEventListener("click", () => {
    console.log("Parsing address");
 
-   // grab input data from url
+   // grab input data
    let input_address = document.getElementById("address").value;
-   // let input_address = window.location.href.split("&")[1].split("=")[1].split("+").join(" ")
    console.log(input_address);
    let params = {"address": input_address};
-   let url = "http://localhost:8000/api/parse/?" + new URLSearchParams(params).toString()
-   console.log(url)
+   let url = "http://localhost:8000/api/parse/?" + new URLSearchParams(params).toString();
+   console.log(url);
 
    // call api
-   let request = fetch(url)   
+   let request = fetch(url);
    request.then((response) => {
       if (response['status'] == 200) {
          response.json()
          .then(data => {
-            console.log(data)
-            console.log(data["address_type"])
             let addr_results_div = document.getElementById("address-results");
+            
+            // Show hidden html element
             addr_results_div.style.display = 'block';
+
+            // Append elements to html
             let addr_type_strong = document.getElementById("parse-type");
-            // var paragraph = document.getElementById("p");
             let addr_type_text = document.createTextNode(data["address_type"]);
             addr_type_strong.appendChild(addr_type_text);
 
-            // var comp_table_body = addr_results_div.children[2].children[1]
-            // // console.log(data["address_components"])
-            // for (const [key, value] of Object.entries(data["address_components"])) {
-            //    console.log(key);
-            //    console.log(value);
-            //    let tr = document.createElement("tr");
-            //    let th1 = document.createElement("th");
-            //    let th2 = document.createElement("th");
-            //    let addr_comp_type = document.createTextNode(key);
-            //    let addr_comp_text = document.createTextNode(value);
-            //    th1.appendChild(addr_comp_type);
-            //    th2.appendChild(addr_comp_text);
-            //    tr.appendChild(th1);
-            //    tr.appendChild(th2);
+            var comp_table_body = addr_results_div.children[2].children[1]
+            for (const [key, value] of Object.entries(data["address_components"])) {
+               let tr = document.createElement("tr");
+               let th1 = document.createElement("th");
+               let th2 = document.createElement("th");
+               let addr_comp_type = document.createTextNode(key);
+               let addr_comp_text = document.createTextNode(value);
+               th1.appendChild(addr_comp_type);
+               th2.appendChild(addr_comp_text);
+               tr.appendChild(th1);
+               tr.appendChild(th2);
 
-            //    comp_table_body.appendChild(tr);
-            //    console.log(comp_table_body);
-            // }
+               comp_table_body.appendChild(tr);
+            }
          })
       } else {
+         // Display error message
+         let addr_results_div = document.getElementById("address-results");
+         addr_results_div.style.display = 'block';
+         let h3 = document.createElement("h3");
+         let h3_text = document.createTextNode("Invalid address. Please try again with a valid address.");
+         h3.appendChild(h3_text);
+         addr_results_div.appendChild(h3);
+         
          console.log("API error", response["status"]);
       }
 })});

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -4,20 +4,48 @@
 // add on click
 console.log("adding on click method")
 let submit_button = document.getElementById("submit");
-submit_button.addEventListener("click", parse_address());
-
-function parse_address() {
+submit_button.addEventListener("click", parse_address => {
    console.log("Parsing address");
-   // grab input data
+
+   // grab input data from url
    let input_address = document.getElementById("address").value;
+   // let input_address = window.location.href.split("&")[1].split("=")[1].split("+").join(" ")
+   console.log(input_address);
+   let params = {"address": input_address};
+   let url = "http://localhost:8000/api/parse/?" + new URLSearchParams(params).toString()
+   console.log(url)
 
    // call api
-   let request = fetch("",
-                       {method: 'POST',
-                        body: JSON.stringify({"address": input_address})});
-   
-   request.then((response) => response.json())
-          .then(data => {
-            // display data in html
-          })
-}
+   let request = fetch(url)   
+   request.then((response) => {
+      if (response['status'] == 200) {
+         response.json()
+         .then(data => {
+            console.log(data)
+            console.log(data["address_type"])
+            let addr_results_div = document.getElementById("address-results");
+            addr_results_div.style.display = 'show';
+            let addr_type_strong = document.getElementById("parse-type");
+            // var paragraph = document.getElementById("p");
+            let addr_type_text = document.createTextNode(data["address_type"]);
+            addr_type_strong.appendChild(addr_type_text);
+
+            let comp_table_body = addr_results_div.children[2].children[1]
+            for (let component in data["address_components"]) {
+               let tr = document.createElement("tr");
+               let th1 = document.createElement("th");
+               let th2 = document.createElement("th");
+               let addr_comp_type = document.createTextNode(component[0]);
+               let addr_comp_text = document.createTextNode(component[1]);
+               th1.appendChild(addr_comp_type);
+               th2.appendChild(addr_comp_text);
+               tr.appendChild(th1);
+               tr.appendChild(th2);
+
+               comp_table_body.appendChild(tr);
+            }
+         })
+      } else {
+         console.log("API error", response["status"]);
+      }
+})});

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -24,26 +24,30 @@ submit_button.addEventListener("click", parse_address => {
             console.log(data)
             console.log(data["address_type"])
             let addr_results_div = document.getElementById("address-results");
-            addr_results_div.style.display = 'show';
+            addr_results_div.style.display = 'block';
             let addr_type_strong = document.getElementById("parse-type");
             // var paragraph = document.getElementById("p");
             let addr_type_text = document.createTextNode(data["address_type"]);
             addr_type_strong.appendChild(addr_type_text);
 
-            let comp_table_body = addr_results_div.children[2].children[1]
-            for (let component in data["address_components"]) {
-               let tr = document.createElement("tr");
-               let th1 = document.createElement("th");
-               let th2 = document.createElement("th");
-               let addr_comp_type = document.createTextNode(component[0]);
-               let addr_comp_text = document.createTextNode(component[1]);
-               th1.appendChild(addr_comp_type);
-               th2.appendChild(addr_comp_text);
-               tr.appendChild(th1);
-               tr.appendChild(th2);
+            // var comp_table_body = addr_results_div.children[2].children[1]
+            // // console.log(data["address_components"])
+            // for (const [key, value] of Object.entries(data["address_components"])) {
+            //    console.log(key);
+            //    console.log(value);
+            //    let tr = document.createElement("tr");
+            //    let th1 = document.createElement("th");
+            //    let th2 = document.createElement("th");
+            //    let addr_comp_type = document.createTextNode(key);
+            //    let addr_comp_text = document.createTextNode(value);
+            //    th1.appendChild(addr_comp_type);
+            //    th2.appendChild(addr_comp_text);
+            //    tr.appendChild(th1);
+            //    tr.appendChild(th2);
 
-               comp_table_body.appendChild(tr);
-            }
+            //    comp_table_body.appendChild(tr);
+            //    console.log(comp_table_body);
+            // }
          })
       } else {
          console.log("API error", response["status"]);

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -18,7 +18,8 @@
         </form>
       </div>
       <!-- TODO: Display parsed address components here. -->
-      <div id="address-results" style="display:none">
+      <!-- style="display:none" -->
+      <div id="address-results">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
         <table class="table table-bordered">

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -18,8 +18,7 @@
         </form>
       </div>
       <!-- TODO: Display parsed address components here. -->
-      <!-- style="display:none" -->
-      <div id="address-results">
+      <div id="address-results" style="display:none">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
         <table class="table table-bordered">
@@ -39,6 +38,5 @@
 {% endblock %}
 
 {% block extra_js %}
-  <!-- <script src="{% static 'js/index.js' %}"></script> -->
-  <script type="text/javascript" src="../../static/js/index.js"></script>
+  <script src="{% static 'js/index.js' %}"></script>
 {% endblock %}

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -38,5 +38,6 @@
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{% static 'js/index.js' %}"></script>
+  <!-- <script src="{% static 'js/index.js' %}"></script> -->
+  <script type="text/javascript" src="../../static/js/index.js"></script>
 {% endblock %}

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -3,7 +3,7 @@ from django.views.generic import TemplateView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
-from rest_framework.exceptions import ParseError
+# from rest_framework.exceptions import ParseError
 
 
 class Home(TemplateView):

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -21,4 +21,7 @@ class AddressParse(APIView):
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
+
+        address_components, address_type = usaddress.tag(address)
+
         return address_components, address_type

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -16,23 +16,18 @@ class AddressParse(APIView):
     def get(self, request):
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        # print(request.data)
-        print(request.query_params["address"])
         address = request.query_params["address"]
 
         response = self.parse(address)
-        # print(response.status_code)
-        # print(response.data)
         if response.status_code == 200:
-            print("RETURNING")
             return Response({"input_string": address,
                              "address_components": response.data["address_components"],
                              "address_type": response.data["address_type"]},
-                             status=response.status_code)
+                            status=response.status_code)
         return Response({"input_string": response.data["original_string"],
                          "address_components": response.data["parsed_string"],
                          "address_type": "Unknown"},
-                         status=response.status_code)
+                        status=response.status_code)
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
@@ -45,8 +40,8 @@ class AddressParse(APIView):
         except usaddress.RepeatedLabelError as e:
             return Response({"parsed_string": e.parsed_string,
                              "original_string": e.original_string},
-                             status=400)
+                            status=400)
 
         return Response({"address_components": address_components,
                          "address_type": address_type},
-                         status=200)
+                        status=200)

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -16,12 +16,33 @@ class AddressParse(APIView):
     def get(self, request):
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        return Response({})
+        print(request)
+        address = request.data["address"]
+
+        response = self.parse(address)
+        if response["status"] == 200:
+            return Response({"status": response["status"],
+                             "input_string": address,
+                             "address_components": response["address_components"],
+                             "address_type": response["address_type"]})
+        return Response({"status": 400,
+                         "input_string": response["original_string"],
+                         "address_components": response["parsed_string"],
+                         "address_type": "Unknown"})
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
 
-        address_components, address_type = usaddress.tag(address)
+        # https://usaddress.readthedocs.io/en/latest/
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses
+        try:
+            address_components, address_type = usaddress.tag(address)
+        except usaddress.RepeatedLabelError as e:
+            return Response({"status": 400,
+                             "parsed_string": e.parsed_string,
+                             "original_string": e.original_string})
 
-        return address_components, address_type
+        return Response({"status": 200,
+                         "address_components": address_components,
+                         "address_type": address_type})

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -16,19 +16,23 @@ class AddressParse(APIView):
     def get(self, request):
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        print(request)
-        address = request.data["address"]
+        # print(request.data)
+        print(request.query_params["address"])
+        address = request.query_params["address"]
 
         response = self.parse(address)
-        if response["status"] == 200:
-            return Response({"status": response["status"],
-                             "input_string": address,
-                             "address_components": response["address_components"],
-                             "address_type": response["address_type"]})
-        return Response({"status": 400,
-                         "input_string": response["original_string"],
-                         "address_components": response["parsed_string"],
-                         "address_type": "Unknown"})
+        # print(response.status_code)
+        # print(response.data)
+        if response.status_code == 200:
+            print("RETURNING")
+            return Response({"input_string": address,
+                             "address_components": response.data["address_components"],
+                             "address_type": response.data["address_type"]},
+                             status=response.status_code)
+        return Response({"input_string": response.data["original_string"],
+                         "address_components": response.data["parsed_string"],
+                         "address_type": "Unknown"},
+                         status=response.status_code)
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
@@ -39,10 +43,10 @@ class AddressParse(APIView):
         try:
             address_components, address_type = usaddress.tag(address)
         except usaddress.RepeatedLabelError as e:
-            return Response({"status": 400,
-                             "parsed_string": e.parsed_string,
-                             "original_string": e.original_string})
+            return Response({"parsed_string": e.parsed_string,
+                             "original_string": e.original_string},
+                             status=400)
 
-        return Response({"status": 200,
-                         "address_components": address_components,
-                         "address_type": address_type})
+        return Response({"address_components": address_components,
+                         "address_type": address_type},
+                         status=200)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,4 @@
-import pytest
+# import pytest
 
 
 def test_api_parse_succeeds(client):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,11 +5,13 @@ def test_api_parse_succeeds(client):
     # TODO: Finish this test. Send a request to the API and confirm that the
     # data comes back in the appropriate format.
     address_string = '123 main st chicago il'
-    pytest.fail()
+    address_string_url = "+".join(address_string.split())
+    assert client.get(f"/api/parse/?address={address_string_url}").status_code == 200
 
 
 def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    address_string_url = "+".join(address_string.split())
+    assert client.get(f"/api/parse/?address={address_string_url}").status_code == 400


### PR DESCRIPTION
## Overview

This PR attempts to complete the DataMade Parserator web service. The following changes are included:
* Implemented the parse() method in views.py, which calls the usaddress API and returns a given address' tagged components and address type.
* Completed the get() method in views.py, which takes a given address and calls the parse() method.
* Both parse() and get() methods handle errors and return appropriate response codes.
* Connected the address form to the API via index.js using an onclick method.
* Displays API output to the HTML by creating new elements and appending them to the #address-results div.
* Added unit tests in test_views.py to ensure the API returns expected status codes.

### Demo

Entering a valid address such as 1307 E 60th St, Chicago, IL should result in the following:
![Screen Shot 2022-08-29 at 1 54 51 PM](https://user-images.githubusercontent.com/82831800/187277189-6b81de42-dd10-4f33-94a2-64f3c892cf1e.png)

Entering an invalid address such as 1307 E 60th St, Chicago, IL 60637 1307 E 60th should result in the following:
![Screen Shot 2022-08-29 at 1 27 43 PM](https://user-images.githubusercontent.com/82831800/187272254-79216b8f-dcba-4770-acdf-d1a114329073.png)

### Notes

This PR includes a major bug. At the moment, when a user clicks the 'Parse!' button, the AddressParse API is called as expected and returns the anticipated responses. New HTML elements are then created and appended to the existing index.html to display the expected output. However, the new HTML elements are appended to the original page at http://localhost:8000/. The page then reloads from http://localhost:8000/ to http://localhost:8000/?csrfmiddlewaretoken=4RbzPzKx4K39GAJZP95pVNLKmiYhmtTOGbH5TesDijxa2Syz01DTE8kSjsIKJmiH&address=1307+E+60th+St%2C+Chicago%2C+IL. Once the page reloads, the newly appended HTML elements do not exist as the page is rebuilt using the original index.html. The reloading of the page is unwanted behavior, and I was unable to prevent it from happening. If I had more time, I would have tried to figure out how to disable the reloading of the page, or alternatively figure out a way to append the new HTML elements to the reloaded page. To acquire the screenshots in the above examples, I simply used the back button to reload the previous page.

Additionally, when running the unit tests, I get the following error:
<img width="617" alt="Screen Shot 2022-08-29 at 1 37 48 PM" src="https://user-images.githubusercontent.com/82831800/187273887-abaed2c3-6e75-4fa4-b8ff-de0fd80b14f0.png">
I ran our of time to debug this error, but from an initial Google search this might be one possible solution:
https://stackoverflow.com/questions/36001552/eslint-parsing-error-unexpected-token

## Testing Instructions
* To test this PR, make sure that [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on your local machine.
* Once you have Docker and Docker Compose installed and have checked out this branch, run the following from the command line:
$ docker-compose build
$ docker-compose up
* Next, you should be able to visit http://localhost:8000/ to test the Parserator.
* Example tests and their expected outputs can be seen in the Demo section above.
* You can run the unit tests by running the following from the command line:
$ docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app